### PR TITLE
Updates error message and help text to include the CHAT prefix

### DIFF
--- a/app.js
+++ b/app.js
@@ -112,7 +112,7 @@ app.post('/link', jsonParser, function (req, res) {
 			break;
 		case "?":
 			res.json({
-				message: "Simply type /link followed by a full INC, KB, CON, PRB, RITM, REQ, ITSK, TASK, or CHG number (including it's descriptor i.e. ‘INC’) and INCBot will return a link to the page. Note that the bot cannot check whether it is a valid number, only that it is formatted correctly. Put together by Phil, 2017. Version 2.1",
+				message: "Type /link followed by a full INC, KB, CON, PRB, RITM, REQ, ITSK, TASK, CHG, or CHAT number (including it's descriptor i.e. ‘INC’) and Link Bot will return a link to the page. Note that the bot cannot check whether it is a valid number, only that it is formatted correctly. Put together by Phil, 2017. Version 2.1",
 				color: 'yellow',
 				message_format: 'text'
 			});
@@ -126,7 +126,7 @@ app.post('/link', jsonParser, function (req, res) {
 
 		default:
 			res.json({
-				message: "Either that isn't an INC, KB, PRB, CON, PRB, RITM, REQ, ITSK, TASK, or CHG number - or Phil coded me wrong :(  (Phil probably did everything right...! –Kyle)",
+				message: "Either that isn't an INC, KB, PRB, CON, PRB, RITM, REQ, ITSK, TASK, CHAT, or CHG number - or Phil coded me wrong :(  (Don't be so critical, Phil. You probably did everything right... –Kyle)",
 				color: 'red',
 				message_format: 'text'
 			});

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
+    "pm2": "^2.10",
     "body-parser": "^1.17.2",
     "express": "^4.13.3"
   },


### PR DESCRIPTION
No additional code changes were required for this functionality since CHG and CHAT prefixes are handled by the CH wildcard and both are just text searches.